### PR TITLE
feat: add candidate schema

### DIFF
--- a/backend/src/events/candidate-names.ts
+++ b/backend/src/events/candidate-names.ts
@@ -1,0 +1,235 @@
+import { z } from "zod";
+import { logger } from "../lib/logger.js";
+import { recordAudit } from "../lib/audit.js";
+import { countRequest, countError, countRateLimit } from "../lib/metrics.js";
+import { CandidateNameModel } from "../models/candidate-name.js";
+import { redis } from "../server.js";
+import { cacheRedis } from "../lib/cache.js";
+import type { Server, Socket } from "socket.io";
+
+const addSchema = z.object({ name: z.string().min(1) });
+const updateSchema = z.object({ id: z.string(), name: z.string().min(1) });
+
+function formatError(
+  code: "AUTH" | "VALIDATION" | "DB" | "RBAC" | "RATE_LIMIT" | "CACHE",
+  message: string,
+  fields?: Record<string, unknown>,
+) {
+  return { code, message, ...(fields ? { fields } : {}) };
+}
+
+export function registerCandidateNameEvents(io: Server) {
+  io.on("connection", (socket: Socket) => {
+    socket.on("candidateNames:add", async (payload) => {
+      countRequest("candidateNames:add");
+      const user = socket.data.user;
+      if (user?.role !== "marketingManager") {
+        socket.emit("candidateNames:error", formatError("RBAC", "Forbidden"));
+        logger.warn(
+          { event: "candidateNames:add", status: "error", userId: user?.id },
+          "rbac",
+        );
+        await recordAudit({
+          event: "candidateNames:add",
+          userId: user?.id,
+          role: user?.role,
+          branchId: user?.branchId,
+          ip: socket.handshake.address,
+          payloadSummary: { rbac: true },
+        });
+        return;
+      }
+      const parse = addSchema.safeParse(payload ?? {});
+      if (!parse.success) {
+        const fields = parse.error.flatten().fieldErrors;
+        socket.emit(
+          "candidateNames:error",
+          formatError("VALIDATION", "Invalid payload", fields),
+        );
+        logger.warn(
+          {
+            event: "candidateNames:add",
+            status: "error",
+            userId: user.id,
+          },
+          "validation failed",
+        );
+        await recordAudit({
+          event: "candidateNames:add",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { ...payload },
+          ip: socket.handshake.address,
+        });
+        return;
+      }
+      const key = `ratelimit:${user.id}:candidateNames:add`;
+      const count = await redis.incr(key);
+      if (count === 1) await redis.expire(key, 60);
+      if (count > 10) {
+        socket.emit(
+          "candidateNames:error",
+          formatError("RATE_LIMIT", "Too many requests"),
+        );
+        logger.warn(
+          { event: "candidateNames:add", status: "error", userId: user.id },
+          "rate limit exceeded",
+        );
+        countRateLimit("candidateNames:add");
+        await recordAudit({
+          event: "candidateNames:add",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { rateLimited: true },
+          ip: socket.handshake.address,
+        });
+        return;
+      }
+      try {
+        const doc = await CandidateNameModel.create({
+          name: parse.data.name,
+          createdBy: user.id,
+          updatedBy: user.id,
+        });
+        await cacheRedis.del("lists:candidateNames");
+        socket.emit("candidateNames:added", {
+          candidateName: { id: doc._id.toString(), name: doc.name },
+        });
+        await recordAudit({
+          event: "candidateNames:add",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { name: parse.data.name },
+          ip: socket.handshake.address,
+        });
+      } catch (e) {
+        socket.emit(
+          "candidateNames:error",
+          formatError("DB", "Failed to add candidate name"),
+        );
+        logger.error({
+          event: "candidateNames:add",
+          status: "error",
+          userId: user.id,
+          err: e,
+        });
+        countError("candidateNames:add");
+      }
+    });
+
+    socket.on("candidateNames:update", async (payload) => {
+      countRequest("candidateNames:update");
+      const user = socket.data.user;
+      if (user?.role !== "marketingManager") {
+        socket.emit("candidateNames:error", formatError("RBAC", "Forbidden"));
+        logger.warn(
+          {
+            event: "candidateNames:update",
+            status: "error",
+            userId: user?.id,
+          },
+          "rbac",
+        );
+        await recordAudit({
+          event: "candidateNames:update",
+          userId: user?.id,
+          role: user?.role,
+          branchId: user?.branchId,
+          ip: socket.handshake.address,
+          payloadSummary: { rbac: true },
+        });
+        return;
+      }
+      const parse = updateSchema.safeParse(payload ?? {});
+      if (!parse.success) {
+        const fields = parse.error.flatten().fieldErrors;
+        socket.emit(
+          "candidateNames:error",
+          formatError("VALIDATION", "Invalid payload", fields),
+        );
+        logger.warn(
+          {
+            event: "candidateNames:update",
+            status: "error",
+            userId: user.id,
+          },
+          "validation failed",
+        );
+        await recordAudit({
+          event: "candidateNames:update",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { ...payload },
+          ip: socket.handshake.address,
+        });
+        return;
+      }
+      const key = `ratelimit:${user.id}:candidateNames:update`;
+      const count = await redis.incr(key);
+      if (count === 1) await redis.expire(key, 60);
+      if (count > 10) {
+        socket.emit(
+          "candidateNames:error",
+          formatError("RATE_LIMIT", "Too many requests"),
+        );
+        logger.warn(
+          {
+            event: "candidateNames:update",
+            status: "error",
+            userId: user.id,
+          },
+          "rate limit exceeded",
+        );
+        countRateLimit("candidateNames:update");
+        await recordAudit({
+          event: "candidateNames:update",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { rateLimited: true },
+          ip: socket.handshake.address,
+        });
+        return;
+      }
+      try {
+        const doc = await CandidateNameModel.findByIdAndUpdate(
+          parse.data.id,
+          { name: parse.data.name, updatedBy: user.id },
+          { new: true, runValidators: true },
+        ).lean();
+        if (!doc) {
+          socket.emit("candidateNames:error", formatError("DB", "Not found"));
+          return;
+        }
+        await cacheRedis.del("lists:candidateNames");
+        socket.emit("candidateNames:updated", {
+          candidateName: { id: doc._id.toString(), name: doc.name },
+        });
+        await recordAudit({
+          event: "candidateNames:update",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { id: parse.data.id, name: parse.data.name },
+          ip: socket.handshake.address,
+        });
+      } catch (e) {
+        socket.emit(
+          "candidateNames:error",
+          formatError("DB", "Failed to update candidate name"),
+        );
+        logger.error({
+          event: "candidateNames:update",
+          status: "error",
+          userId: user.id,
+          err: e,
+        });
+        countError("candidateNames:update");
+      }
+    });
+  });
+}

--- a/backend/src/events/companies.ts
+++ b/backend/src/events/companies.ts
@@ -1,0 +1,219 @@
+import { z } from "zod";
+import { logger } from "../lib/logger.js";
+import { recordAudit } from "../lib/audit.js";
+import { countRequest, countError, countRateLimit } from "../lib/metrics.js";
+import { CompanyModel } from "../models/company.js";
+import { redis } from "../server.js";
+import { cacheRedis } from "../lib/cache.js";
+import type { Server, Socket } from "socket.io";
+
+const addSchema = z.object({ name: z.string().min(1) });
+const updateSchema = z.object({ id: z.string(), name: z.string().min(1) });
+
+function formatError(
+  code: "AUTH" | "VALIDATION" | "DB" | "RBAC" | "RATE_LIMIT" | "CACHE",
+  message: string,
+  fields?: Record<string, unknown>,
+) {
+  return { code, message, ...(fields ? { fields } : {}) };
+}
+
+export function registerCompanyEvents(io: Server) {
+  io.on("connection", (socket: Socket) => {
+    socket.on("companies:add", async (payload) => {
+      countRequest("companies:add");
+      const user = socket.data.user;
+      if (user?.role !== "marketingManager") {
+        socket.emit("companies:error", formatError("RBAC", "Forbidden"));
+        logger.warn(
+          { event: "companies:add", status: "error", userId: user?.id },
+          "rbac",
+        );
+        await recordAudit({
+          event: "companies:add",
+          userId: user?.id,
+          role: user?.role,
+          branchId: user?.branchId,
+          ip: socket.handshake.address,
+          payloadSummary: { rbac: true },
+        });
+        return;
+      }
+      const parse = addSchema.safeParse(payload ?? {});
+      if (!parse.success) {
+        const fields = parse.error.flatten().fieldErrors;
+        socket.emit(
+          "companies:error",
+          formatError("VALIDATION", "Invalid payload", fields),
+        );
+        logger.warn(
+          { event: "companies:add", status: "error", userId: user.id },
+          "validation failed",
+        );
+        await recordAudit({
+          event: "companies:add",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { ...payload },
+          ip: socket.handshake.address,
+        });
+        return;
+      }
+      const key = `ratelimit:${user.id}:companies:add`;
+      const count = await redis.incr(key);
+      if (count === 1) await redis.expire(key, 60);
+      if (count > 10) {
+        socket.emit(
+          "companies:error",
+          formatError("RATE_LIMIT", "Too many requests"),
+        );
+        logger.warn(
+          { event: "companies:add", status: "error", userId: user.id },
+          "rate limit exceeded",
+        );
+        countRateLimit("companies:add");
+        await recordAudit({
+          event: "companies:add",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { rateLimited: true },
+          ip: socket.handshake.address,
+        });
+        return;
+      }
+      try {
+        const doc = await CompanyModel.create({
+          name: parse.data.name,
+          createdBy: user.id,
+          updatedBy: user.id,
+        });
+        await cacheRedis.del("lists:companies");
+        socket.emit("companies:added", {
+          company: { id: doc._id.toString(), name: doc.name },
+        });
+        await recordAudit({
+          event: "companies:add",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { name: parse.data.name },
+          ip: socket.handshake.address,
+        });
+      } catch (e) {
+        socket.emit(
+          "companies:error",
+          formatError("DB", "Failed to add company"),
+        );
+        logger.error({
+          event: "companies:add",
+          status: "error",
+          userId: user.id,
+          err: e,
+        });
+        countError("companies:add");
+      }
+    });
+
+    socket.on("companies:update", async (payload) => {
+      countRequest("companies:update");
+      const user = socket.data.user;
+      if (user?.role !== "marketingManager") {
+        socket.emit("companies:error", formatError("RBAC", "Forbidden"));
+        logger.warn(
+          { event: "companies:update", status: "error", userId: user?.id },
+          "rbac",
+        );
+        await recordAudit({
+          event: "companies:update",
+          userId: user?.id,
+          role: user?.role,
+          branchId: user?.branchId,
+          ip: socket.handshake.address,
+          payloadSummary: { rbac: true },
+        });
+        return;
+      }
+      const parse = updateSchema.safeParse(payload ?? {});
+      if (!parse.success) {
+        const fields = parse.error.flatten().fieldErrors;
+        socket.emit(
+          "companies:error",
+          formatError("VALIDATION", "Invalid payload", fields),
+        );
+        logger.warn(
+          { event: "companies:update", status: "error", userId: user.id },
+          "validation failed",
+        );
+        await recordAudit({
+          event: "companies:update",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { ...payload },
+          ip: socket.handshake.address,
+        });
+        return;
+      }
+      const key = `ratelimit:${user.id}:companies:update`;
+      const count = await redis.incr(key);
+      if (count === 1) await redis.expire(key, 60);
+      if (count > 10) {
+        socket.emit(
+          "companies:error",
+          formatError("RATE_LIMIT", "Too many requests"),
+        );
+        logger.warn(
+          { event: "companies:update", status: "error", userId: user.id },
+          "rate limit exceeded",
+        );
+        countRateLimit("companies:update");
+        await recordAudit({
+          event: "companies:update",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { rateLimited: true },
+          ip: socket.handshake.address,
+        });
+        return;
+      }
+      try {
+        const doc = await CompanyModel.findByIdAndUpdate(
+          parse.data.id,
+          { name: parse.data.name, updatedBy: user.id },
+          { new: true, runValidators: true },
+        ).lean();
+        if (!doc) {
+          socket.emit("companies:error", formatError("DB", "Not found"));
+          return;
+        }
+        await cacheRedis.del("lists:companies");
+        socket.emit("companies:updated", {
+          company: { id: doc._id.toString(), name: doc.name },
+        });
+        await recordAudit({
+          event: "companies:update",
+          userId: user.id,
+          role: user.role,
+          branchId: user.branchId,
+          payloadSummary: { id: parse.data.id, name: parse.data.name },
+          ip: socket.handshake.address,
+        });
+      } catch (e) {
+        socket.emit(
+          "companies:error",
+          formatError("DB", "Failed to update company"),
+        );
+        logger.error({
+          event: "companies:update",
+          status: "error",
+          userId: user.id,
+          err: e,
+        });
+        countError("companies:update");
+      }
+    });
+  });
+}

--- a/backend/src/events/lists.ts
+++ b/backend/src/events/lists.ts
@@ -5,6 +5,8 @@ import { countRequest, countError } from "../lib/metrics.js";
 import { BranchModel } from "../models/branch.js";
 import { DepartmentModel } from "../models/department.js";
 import { TeamModel } from "../models/team.js";
+import { CandidateNameModel } from "../models/candidate-name.js";
+import { CompanyModel } from "../models/company.js";
 import { getJson, setJson } from "../lib/cache.js";
 import type { Server, Socket } from "socket.io";
 
@@ -67,6 +69,14 @@ export function registerListEvents(io: Server) {
           branchId?: string;
           departmentId?: string;
         }
+        interface CandidateNameList {
+          id: string;
+          name: string;
+        }
+        interface CompanyList {
+          id: string;
+          name: string;
+        }
 
         let branches = await getJson<BranchList[]>("lists", "branches");
         if (!branches) {
@@ -78,7 +88,10 @@ export function registerListEvents(io: Server) {
           }));
           await setJson("lists", "branches", branches, TTL);
         }
-        let departments = await getJson<DepartmentList[]>("lists", "departments");
+        let departments = await getJson<DepartmentList[]>(
+          "lists",
+          "departments",
+        );
         if (!departments) {
           const docs = await DepartmentModel.find()
             .select("code name branchId")
@@ -105,6 +118,27 @@ export function registerListEvents(io: Server) {
           }));
           await setJson("lists", "teams", teams, TTL);
         }
+        let candidateNames = await getJson<CandidateNameList[]>(
+          "lists",
+          "candidateNames",
+        );
+        if (!candidateNames) {
+          const docs = await CandidateNameModel.find().select("name").lean();
+          candidateNames = docs.map((c) => ({
+            id: c._id.toString(),
+            name: c.name,
+          }));
+          await setJson("lists", "candidateNames", candidateNames, TTL);
+        }
+        let companies = await getJson<CompanyList[]>("lists", "companies");
+        if (!companies) {
+          const docs = await CompanyModel.find().select("name").lean();
+          companies = docs.map((c) => ({
+            id: c._id.toString(),
+            name: c.name,
+          }));
+          await setJson("lists", "companies", companies, TTL);
+        }
         const departmentsByBranch = departments.reduce<
           Record<string, DepartmentList[]>
         >((acc, d) => {
@@ -124,6 +158,8 @@ export function registerListEvents(io: Server) {
           branches,
           departmentsByBranch,
           teamsByDepartment,
+          candidateNames,
+          companies,
         });
         await recordAudit({
           event: "lists:bootstrap",

--- a/backend/src/models/candidate-name.ts
+++ b/backend/src/models/candidate-name.ts
@@ -1,0 +1,18 @@
+import { Schema, model, type InferSchemaType } from "mongoose";
+
+const candidateNameSchema = new Schema(
+  {
+    name: { type: String, required: true, unique: true },
+    createdBy: { type: Schema.Types.ObjectId, ref: "User" },
+    updatedBy: { type: Schema.Types.ObjectId, ref: "User" },
+  },
+  { timestamps: true },
+);
+
+candidateNameSchema.index({ name: 1 }, { unique: true });
+
+export type CandidateName = InferSchemaType<typeof candidateNameSchema>;
+export const CandidateNameModel = model<CandidateName>(
+  "CandidateName",
+  candidateNameSchema,
+);

--- a/backend/src/models/candidate.ts
+++ b/backend/src/models/candidate.ts
@@ -1,0 +1,30 @@
+import { Schema, model, Types, type InferSchemaType } from 'mongoose';
+
+const candidateStatuses = ['Active', 'Non Active', 'Offer', 'Backout'] as const;
+
+const candidateSchema = new Schema(
+  {
+    candidateNameId: { type: Types.ObjectId, ref: 'CandidateName', required: true },
+    companyId: { type: Types.ObjectId, ref: 'Company', required: true },
+    status: { type: String, enum: candidateStatuses, required: true },
+    recruiterId: { type: Types.ObjectId, ref: 'User' },
+    teamLeadId: { type: Types.ObjectId, ref: 'User' },
+    branchId: { type: Types.ObjectId, ref: 'Branch' },
+    departmentId: { type: Types.ObjectId, ref: 'Department' },
+    gender: { type: String },
+    email: { type: String },
+    phone: { type: String },
+    createdBy: { type: Types.ObjectId, ref: 'User' },
+    updatedBy: { type: Types.ObjectId, ref: 'User' },
+  },
+  { timestamps: true }
+);
+
+candidateSchema.index({ recruiterId: 1 });
+candidateSchema.index({ teamLeadId: 1 });
+candidateSchema.index({ companyId: 1 });
+candidateSchema.index({ branchId: 1, departmentId: 1 });
+candidateSchema.index({ status: 1, createdAt: -1 });
+
+export type Candidate = InferSchemaType<typeof candidateSchema>;
+export const CandidateModel = model<Candidate>('Candidate', candidateSchema);

--- a/backend/src/models/company.ts
+++ b/backend/src/models/company.ts
@@ -1,0 +1,15 @@
+import { Schema, model, type InferSchemaType } from "mongoose";
+
+const companySchema = new Schema(
+  {
+    name: { type: String, required: true, unique: true },
+    createdBy: { type: Schema.Types.ObjectId, ref: "User" },
+    updatedBy: { type: Schema.Types.ObjectId, ref: "User" },
+  },
+  { timestamps: true },
+);
+
+companySchema.index({ name: 1 }, { unique: true });
+
+export type Company = InferSchemaType<typeof companySchema>;
+export const CompanyModel = model<Company>("Company", companySchema);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,9 +15,14 @@ import { DepartmentModel } from "./models/department.js";
 import { TeamModel } from "./models/team.js";
 import { UserModel } from "./models/user.js";
 import { TaskModel } from "./models/task.js";
+import { CandidateModel } from "./models/candidate.js";
+import { CandidateNameModel } from "./models/candidate-name.js";
+import { CompanyModel } from "./models/company.js";
 import { registerAuthEvents } from "./events/auth.js";
 import { registerTaskEvents } from "./events/tasks.js";
 import { registerListEvents } from "./events/lists.js";
+import { registerCandidateNameEvents } from "./events/candidate-names.js";
+import { registerCompanyEvents } from "./events/companies.js";
 import { cacheRedis } from "./lib/cache.js";
 
 const app = express();
@@ -36,6 +41,8 @@ io.adapter(createAdapter(pubClient, subClient));
 registerAuthEvents(io);
 registerTaskEvents(io);
 registerListEvents(io);
+registerCandidateNameEvents(io);
+registerCompanyEvents(io);
 
 const maxPayloadBytes =
   (Number(process.env.MAX_PAYLOAD_SIZE_KB || "4") || 4) * 1024;
@@ -83,7 +90,7 @@ io.use((socket, next) => {
     };
     joinRooms(io, socket, socket.data.user);
     next();
-  } catch (e) {
+  } catch {
     const err = new Error("Unauthorized") as Error & { data?: unknown };
     err.data = formatError("AUTH", "Invalid token");
     next(err);
@@ -162,6 +169,9 @@ export async function start() {
     TeamModel.init(),
     UserModel.init(),
     TaskModel.init(),
+    CandidateModel.init(),
+    CandidateNameModel.init(),
+    CompanyModel.init(),
     AuditModel.init(),
   ]);
   await new Promise<void>((resolve) => server.listen(PORT, () => resolve()));

--- a/backend/test/17-candidate-company-rbac.spec.ts
+++ b/backend/test/17-candidate-company-rbac.spec.ts
@@ -1,0 +1,172 @@
+/* eslint-disable */
+/* eslint-env node, jest */
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { io as Client } from "socket.io-client";
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+import { UserModel } from "../src/models/user.js";
+import { Adapter } from "socket.io-adapter";
+import type { Server as HTTPServer } from "http";
+
+jest.setTimeout(20000);
+
+jest.mock("ioredis", () => {
+  class RedisMock {
+    store = new Map<string, unknown>();
+    duplicate() {
+      return new RedisMock();
+    }
+    incr(key: string) {
+      const v = ((this.store.get(key) as number | undefined) || 0) + 1;
+      this.store.set(key, v);
+      return Promise.resolve(v);
+    }
+    expire() {
+      return Promise.resolve(1);
+    }
+    ping() {
+      return Promise.resolve("PONG");
+    }
+    get(key: string) {
+      return Promise.resolve(this.store.get(key));
+    }
+    set(key: string, val: string) {
+      this.store.set(key, val);
+      return Promise.resolve("OK");
+    }
+    del(key: string) {
+      this.store.delete(key);
+      return Promise.resolve(1);
+    }
+    quit() {
+      return Promise.resolve();
+    }
+  }
+  return RedisMock;
+});
+
+jest.mock("@socket.io/redis-adapter", () => ({ createAdapter: () => Adapter }));
+
+describe("candidate name and company events", () => {
+  let mongod: MongoMemoryServer;
+  let start: () => Promise<unknown>,
+    shutdown: () => Promise<void>,
+    server: HTTPServer;
+  let url: string;
+  let managerToken: string;
+  let recruiterToken: string;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    process.env.MONGODB_URI = mongod.getUri();
+    process.env.JWT_SECRET = "testsecret";
+    process.env.PORT = "6013";
+    process.env.REDIS_URL = "redis://localhost:6379";
+    ({ start, shutdown, server } = await import("../src/server.js"));
+    await start();
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    url = `http://localhost:${port}`;
+
+    const manager = await UserModel.create({
+      email: "mgr@example.com",
+      passwordHash: await bcrypt.hash("secret", 10),
+      role: "marketingManager",
+    });
+    managerToken = jwt.sign(
+      { sub: manager._id.toString(), role: "marketingManager" },
+      process.env.JWT_SECRET as string,
+    );
+
+    const recruiter = await UserModel.create({
+      email: "rec@example.com",
+      passwordHash: await bcrypt.hash("secret", 10),
+      role: "recruiter",
+    });
+    recruiterToken = jwt.sign(
+      { sub: recruiter._id.toString(), role: "recruiter" },
+      process.env.JWT_SECRET as string,
+    );
+  });
+
+  afterAll(async () => {
+    await shutdown();
+    await mongod.stop();
+  });
+
+  it("allows marketingManager to add candidate name and company", async () => {
+    const client = Client(url, {
+      transports: ["websocket"],
+      auth: { token: managerToken },
+    });
+    await new Promise<void>((resolve) => client.on("connect", resolve));
+
+    const cname = await new Promise<{
+      type: string;
+      data: { candidateName: { name: string } };
+    }>((resolve) => {
+      client.once("candidateNames:added", (data) =>
+        resolve({ type: "added", data }),
+      );
+      client.once("candidateNames:error", (data) =>
+        resolve({ type: "error", data }),
+      );
+      client.emit("candidateNames:add", { name: "John Doe" });
+    });
+    expect(cname.type).toBe("added");
+    expect(cname.data.candidateName.name).toBe("John Doe");
+
+    const comp = await new Promise<{
+      type: string;
+      data: { company: { name: string } };
+    }>((resolve) => {
+      client.once("companies:added", (data) =>
+        resolve({ type: "added", data }),
+      );
+      client.once("companies:error", (data) =>
+        resolve({ type: "error", data }),
+      );
+      client.emit("companies:add", { name: "Acme Corp" });
+    });
+    expect(comp.type).toBe("added");
+    expect(comp.data.company.name).toBe("Acme Corp");
+    client.close();
+  });
+
+  it("blocks non-manager from adding candidate name and company", async () => {
+    const client = Client(url, {
+      transports: ["websocket"],
+      auth: { token: recruiterToken },
+    });
+    await new Promise<void>((resolve) => client.on("connect", resolve));
+
+    const cname = await new Promise<{ type: string; data: { code?: string } }>(
+      (resolve) => {
+        client.once("candidateNames:error", (data) =>
+          resolve({ type: "error", data }),
+        );
+        client.once("candidateNames:added", (data) =>
+          resolve({ type: "added", data }),
+        );
+        client.emit("candidateNames:add", { name: "Jane" });
+      },
+    );
+    expect(cname.type).toBe("error");
+    expect(cname.data.code).toBe("RBAC");
+
+    const comp = await new Promise<{ type: string; data: { code?: string } }>(
+      (resolve) => {
+        client.once("companies:error", (data) =>
+          resolve({ type: "error", data }),
+        );
+        client.once("companies:added", (data) =>
+          resolve({ type: "added", data }),
+        );
+        client.emit("companies:add", { name: "Beta Inc" });
+      },
+    );
+    expect(comp.type).toBe("error");
+    expect(comp.data.code).toBe("RBAC");
+    client.close();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "frontend"
       ],
       "devDependencies": {
+        "@eslint/js": "^9.9.0",
         "eslint": "^9.13.0",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.7",
@@ -42,11 +43,6 @@
         "@typescript-eslint/parser": "^8.40.0",
         "eslint": "^9.13.0",
         "globals": "^15.9.0",
-
-        "@types/supertest": "^2.0.12",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
-        "eslint": "^8.56.0",
         "ioredis-mock": "^5.9.1",
         "jest": "^29.7.0",
         "mongodb-memory-server": "^10.1.4",
@@ -56,8 +52,6 @@
         "redis-commands": "^1.7.0",
         "socket.io-client": "^4.7.5",
         "supertest": "^7.1.4",
-        "supertest": "^6.3.4",
-
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
         "tsup": "^7.2.0",
@@ -2352,7 +2346,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-
     "frontend/node_modules/eventemitter3": {
       "version": "4.0.7",
       "license": "MIT"
@@ -4094,7 +4087,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
       "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4102,7 +4094,6 @@
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
-
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -4111,7 +4102,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4128,7 +4118,6 @@
       },
       "funding": {
         "url": "https://eslint.org/donate"
-
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -5612,7 +5601,6 @@
         "@types/react": "^18.0.0"
       }
     },
-
     "node_modules/@types/send": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
@@ -5992,7 +5980,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
@@ -8597,7 +8584,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8606,7 +8592,6 @@
       },
       "engines": {
         "node": ">=16"
-
       }
     },
     "node_modules/flatted": {
@@ -8707,7 +8692,6 @@
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-
         "once": "^1.4.0"
       },
       "engines": {
@@ -9583,7 +9567,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -13966,7 +13949,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
       "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
-
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,19 +11,15 @@
     "prepare": "husky install"
   },
   "devDependencies": {
+    "@eslint/js": "^9.9.0",
+    "eslint": "^9.13.0",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.7",
-    "prettier": "^3.3.3",
-    "eslint": "^9.13.0"
+    "prettier": "^3.3.3"
   },
   "lint-staged": {
     "backend/**/*.{js,ts,tsx}": [
       "eslint --fix --config backend/eslint.config.js",
-    "eslint": "^8.57.1"
-  },
-  "lint-staged": {
-    "backend/**/*.{js,ts,tsx}": [
-      "eslint --fix --config backend/.eslintrc.cjs",
       "prettier --write"
     ],
     "frontend/**/*.{js,ts,tsx}": [


### PR DESCRIPTION
### Summary
- define candidate schema with status enum and indexes
- add curated candidate name and company lists with manager-only mutations
- include @eslint/js for linting

### Events
- `candidateNames:add` request/response
- `candidateNames:update` request/response
- `companies:add` request/response
- `companies:update` request/response

### Tests
- `npm run lint` *(fails: Unexpected any and no-undef errors)*
- `npm test`

### Rollback Plan
- revert commits

------
https://chatgpt.com/codex/tasks/task_b_68a4e4fa5a748329a42c87b90ab07ec2